### PR TITLE
add defaultQueue update for many queue in only class

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
    <modelVersion>4.0.0</modelVersion>
    <groupId>io.2060</groupId>
    <artifactId>service-agent-java-client</artifactId>
-   <version>2.0.2</version>
+   <version>2.0.3</version>
    <properties>
       <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
       <maven.compiler.source>17</maven.compiler.source>
@@ -111,7 +111,7 @@
                         <goal>sign</goal>
                      </goals>
                      <configuration>
-                        <keyname>58BA9C734D6C15DD33C63ACC086B1A209C4D922A</keyname>
+                        <keyname>A0E745610E1F1E571F106FB488B0D4FF7C070E5B</keyname>
                      </configuration>
                   </execution>
                </executions>

--- a/src/main/java/io/twentysixty/sa/client/jms/AbstractProducer.java
+++ b/src/main/java/io/twentysixty/sa/client/jms/AbstractProducer.java
@@ -195,6 +195,10 @@ public abstract class AbstractProducer implements ProducerInterface {
 		this.debug = debug;
 	}
 
+	public void setDefaultQueue(Queue queue) {
+        this.defaultQueue = queue;
+    }
+
 	@Override
 	public void sendMessage(BaseMessage message) throws Exception {
 		// TODO Auto-generated method stub

--- a/src/main/java/io/twentysixty/sa/client/jms/ConsumerInterface.java
+++ b/src/main/java/io/twentysixty/sa/client/jms/ConsumerInterface.java
@@ -1,7 +1,5 @@
 package io.twentysixty.sa.client.jms;
 
-import jakarta.jms.ObjectMessage;
-
 import io.twentysixty.sa.client.model.message.BaseMessage;
 
 


### PR DESCRIPTION
This method allows updating the default queue, enabling control and editing of queues created in any class. This facilitates the ability to have multiple producers for sending messages to the queue